### PR TITLE
Change Node for Compatability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 publish: &publish
   working_directory: ~/MUResourceCenter/my-app
   docker:
-    - image: cimg/node:18.7.0
+    - image: cimg/node:16.17.0
   steps:
     - checkout
 


### PR DESCRIPTION
expo-cli supports following Node.js versions:
* >=12.13.0 <15.0.0 (Maintenance LTS)
* >=16.0.0 <17.0.0 (Active LTS