### PR TITLE
Fix app name for Expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "MU Resource Center",
+    "name": "my-app",
     "slug": "MU Resource Center",
     "version": "1.0.0",
     "orientation": "portrait",


### PR DESCRIPTION
Credentials only have "my-app" right now