### PR TITLE
touchable 3d touch issue fixed

### DIFF
--- a/src/screens/Components/widget2.tsx
+++ b/src/screens/Components/widget2.tsx
@@ -99,7 +99,12 @@ function ResourceButtons(widget, nav) {
 
   const panResponder = useRef(
     PanResponder.create({
-      onMoveShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder(e, gestureState){
+        if (gestureState.dx === 0 || gestureState.dy === 0) {
+          return false;
+        }
+        return true;
+      },
       onPanResponderGrant: () => {
         pan.setOffset({
           x: pan.x._value,


### PR DESCRIPTION
I have been able to workaround this specific issue by making sure the parent PanResponder doesn't grab the responder on move, until the touch has actually moved from the origin